### PR TITLE
add @login_required to student.views.change_enrollment

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -576,6 +576,7 @@ def try_change_enrollment(request):
             log.exception("Exception automatically enrolling after login: {0}".format(str(e)))
 
 
+@login_required
 @require_POST
 def change_enrollment(request):
     """


### PR DESCRIPTION
On residential MITx (rp), the registration page currently doesn't work properly, if the user is not logged in.  Clicking the "register" button just keeps on cycling back to the registration page, without triggering a login.

What happens is that the "register" button does an AJAX POST to /change_enrollment, which calls student.views.change_enrollment ; if the user is not logged in, it throws a 403.  That 403 is supposed to cause a redirect to the login page, but that's not happening.

This attempted fix short circuits this by adding `@login_required` to student.views.change_enrollment ; the login should automagically happen for users who have MIT client certificates.

Note: needs to be tested before deployment

@carsongee 
