### PR TITLE
workaround for custom_tag being broken in residential MITx

### DIFF
--- a/common/lib/xmodule/xmodule/template_module.py
+++ b/common/lib/xmodule/xmodule/template_module.py
@@ -55,7 +55,10 @@ class CustomTagDescriptor(RawDescriptor):
         # cdodge: look up the template as a module
         template_loc = self.location.replace(category='custom_tag_template', name=template_name)
 
-        template_module = system.load_item(template_loc)
+        try:
+            template_module = system.load_item(template_loc)
+        except:
+            template_module = system.load_item(template_loc.for_branch('draft'))
         template_module_data = template_module.data
         template = Template(template_module_data)
         return template.render(**params)


### PR DESCRIPTION
The `<customtag>` construct is supported within edX XML (see http://edx.readthedocs.org/projects/devdata/en/latest/course_data_formats/course_xml.html?highlight=custom_tag#customtag), but currently broken in the residential production MITx stack.  

This feature is needed for 2.01r and 6.00.1

The problem is that the custom_tag/*.xml files are being loaded by XML import as being "revision=draft", instead of "revision=null".  For example:

```
> db.modulestore.find({"_id.course":"2.01r","_id.category":"custom_tag_template"})
{ "_id" : { "tag" : "i4x", "org" : "MITx", "course" : "2.01r", "category" : 
               "custom_tag_template", "name" : "boardnotes", "revision" : "draft" }, 
 "definition" : { "data" ...
```

The proper fix is to figure out the xml importer, and make it import with the right revision.  But all that code is mucked up with split mongo and jazz.

This PR works around the problem by making the template_module (which handles `<customtag>`) search for the module within the "draft" branch, as a fallback, if it is not found in the default way.  

This fix has been tested with the mitx-injera vm, updated to the 21-August rp release, commit c99ac45aec14d2ebff51ac01b25914e288d7d0fd ; the 2.01r course content and its custom tags work properly with this fix.
