### PR TITLE
attempt_stats should exclude anyone in the beta_testers group

### DIFF
--- a/lms/djangoapps/courseware/management/commands/attempt_stats.py
+++ b/lms/djangoapps/courseware/management/commands/attempt_stats.py
@@ -59,7 +59,8 @@ def compute_stats(course_id):
     course_url = pminfo.course.location.url()
     staff_role = roles.CourseStaffRole(course_url)
     inst_role = roles.CourseInstructorRole(course_url)
-    exclude_groups = staff_role._group_names + inst_role._group_names
+    beta_role = roles.CourseBetaTesterRole(course_url)
+    exclude_groups = staff_role._group_names + inst_role._group_names + beta_role._group_names
 
     for rpmod in pminfo.rpmods:
         assignment_set_name = rpmod.ra_ps.display_name


### PR DESCRIPTION
@jtriley  Can you take a look at this? I'm trying to get attempt_stats management command into shape for Kerri & Michael. I think excluding the beta tests (like Tej and me) will address some of the discrepancies I'm seeing. 

Also, I assuming I'm submitting my PR to the correct branch. Let me know if I've got that wrong. 

@carsongee FYI