### PR TITLE
Fix CCX grades csv file download

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -247,4 +247,5 @@ George Schneeloch <gschneel@mit.edu>
 Dustin Gadal <Dustin.Gadal@gmail.com>
 Robert Raposa <rraposa@edx.org>
 Giovanni Di Milia <gdimilia@mit.edu>
+Peter Wilkins <pwilkins@mit.edu>
 Justin Abrahms <abrahms@mit.edu>

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -733,6 +733,12 @@ class TestCCXGrades(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        # Are the grades downloaded as an attachment?
+        self.assertEqual(
+            response['content-disposition'],
+            'attachment'
+        )
+
         headers, row = (
             row.strip().split(',') for row in
             response.content.strip().split('\n')

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -615,4 +615,7 @@ def ccx_grades_csv(request, course, ccx=None):
         for row in rows:
             writer.writerow(row)
 
-        return HttpResponse(buf.getvalue(), content_type='text/plain')
+        response = HttpResponse(buf.getvalue(), content_type='text/csv')
+        response['Content-Disposition'] = 'attachment'
+
+        return response


### PR DESCRIPTION
In the CCX dashboard, the Student Admin tab has a `Download student
grades` action. This action should download a CSV file containing
grades, but currently displays the CSV content in the browser instead.
This fix sets the `content-type` and `content-disposition` so that
a CSV file download occurs.

- fixes #93 

@pdpinch 