### PR TITLE
WIP Added connector setting in course

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -397,6 +397,16 @@ class CourseFields(object):
         default=False,
         scope=Scope.settings
     )
+    ccx_connector = String(
+        # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content.
+        display_name=_("CCX Connector URL"),
+        # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content.
+        help=_(
+            "URL for CCX Connector application for managing creation of CCXs. (optional)."
+            " Ignored unless 'CCX Enabled' is set to 'True'."
+        ),
+        scope=Scope.settings
+    )
     allow_anonymous = Boolean(
         display_name=_("Allow Anonymous Discussion Posts"),
         help=_("Enter true or false. If true, students can create discussion posts that are anonymous to all users."),

--- a/lms/djangoapps/ccx/api.py
+++ b/lms/djangoapps/ccx/api.py
@@ -1,0 +1,29 @@
+import requests
+
+from django.conf import settings
+
+from lms.djangoapps.instructor.access import list_with_level
+
+from lms.djangoapps.courseware.courses import get_course_info_section
+from student.models import unique_id_for_user
+
+
+def send_course_detail_to_ccx_connector(request, course):
+    if course.ccx_connector:
+        list_staff = list_with_level(course, 'staff')
+
+        course_detail = {
+            "title": course.display_name,
+            "author_name": None,
+            "edx_instance": settings.SITE_NAME,
+            "overview": get_course_info_section(request, course, "updates"),
+            "video_url": course.course_image,
+            "instructors": [unique_id_for_user(staff) for staff in list_staff]
+        }
+
+        response = requests.post(
+            course.ccx_connector,
+            data=course_detail
+        )
+
+        print "course_detail: ", course_detail, "response:", response.content

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -51,6 +51,7 @@ from instructor.enrollment import (
     get_email_params,
 )
 
+from lms.djangoapps.ccx.api import send_course_detail_to_ccx_connector
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import (
     get_override_for_ccx,
@@ -208,6 +209,7 @@ def create_ccx(request, course, ccx=None):
         email_params=email_params,
     )
 
+    send_course_detail_to_ccx_connector(request, course)
     return redirect(url)
 
 


### PR DESCRIPTION
> As an initial implementation, this can be done as an advanced setting on the course (similar to enable_ccx). The key should be ccx_connector and the name should be "CCX Connector URL" The help text should be "URL for CCX Connector application for managing creation of CCXs. (optional)"

fixes https://github.com/mitocw/edx-platform/issues/118
@pdpinch 

![screen shot 2015-10-27 at 6 20 00 pm](https://cloud.githubusercontent.com/assets/10431250/10759170/a6eefbc4-7cd7-11e5-8c61-a3d50712f40c.png)