### PR TITLE
Fixed display name ccx course on coach dashboard

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -138,6 +138,9 @@ def dashboard(request, course, ccx=None):
         context['grading_policy'] = json.dumps(grading_policy, indent=4)
         context['grading_policy_url'] = reverse(
             'ccx_set_grading_policy', kwargs={'course_id': ccx_locator})
+
+        with ccx_course(ccx_locator) as course:
+            context['course'] = course
     else:
         context['create_ccx_url'] = reverse(
             'create_ccx', kwargs={'course_id': course.id})


### PR DESCRIPTION
Hi

#### Description
Fixed https://github.com/mitocw/edx-platform/issues/115

- I made this PR to fix ccx display name in coach dashboard.

**Studio Updates:** None.
**LMS Updates:** 
- Fixed display name of ccx inside page header in coach dashboard.

Only ccx will be effect by this PR.
@pdpinch @giocalitri  @pwilkins 

![screen shot 2015-10-30 at 6 10 41 pm](https://cloud.githubusercontent.com/assets/10431250/10846560/56d35a88-7f32-11e5-8822-617e97832aee.png)

#### Pending issue:
issue: https://github.com/mitocw/edx-platform/issues/33 
Now when user clicks the coach tab then dashboard opens in ccx instead of master course. We need to add an active ```ccx coach``` tab inside ccx. This issue is reported as #33 .
**Note:** There is no change in create ccx functionality.