### PR TITLE
Fixed issues on schedule tab, CCX coach dashboard

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -489,7 +489,8 @@ def get_ccx_schedule(course, ccx):
                     'hidden': hidden,
                 }
             if depth < 3:
-                children = tuple(visit(child, depth + 1))
+                children = list(visit(child, depth + 1))
+                children.sort(key=lambda obj: obj['start'])
                 if children:
                     visited['children'] = children
                     yield visited
@@ -497,7 +498,9 @@ def get_ccx_schedule(course, ccx):
                 yield visited
 
     with disable_overrides():
-        return tuple(visit(course))
+        schedule_tree = list(visit(course))
+        schedule_tree.sort(key=lambda obj: obj['start'])
+        return schedule_tree
 
 
 @ensure_csrf_cookie


### PR DESCRIPTION
### Background
Found some minor issue in ccx schedule

##### Issues:
- when user enters a start and due date of subsection aka sequential in ```Add a unit form``` and press ```Add unit``` button  then corresponding start and due dates of verticals (aka units) of that subsection do not update.

- In ```Add a unit form``` when use selects a chapter the show only start date of chapter, when user selects a subsection aka sequential of selected chapter the show start and due date of sequential.
then at this point user unselect sequential by choosing ```All subsections``` the show only start date of chapter. So for vertical aka unit.

- When user updates start date of a chapter aka section the start dates of all its children do not update. In studio aka cms when we update start/release date of a chapter then all start/release dates of its children  **whose due date is not set are update**. 

- https://github.com/mitocw/edx-platform/issues/39

- https://github.com/mitocw/edx-platform/issues/54

### What is done in this PR
**Studio Updates:**  None

**LMS Updates:** 
- Now after entering start date of chapter in ```Add a unit form```,  start date of sequentials and verticals are update only if due date on a  sequential or vertical is not set.

- Now after entering start and due dates of subsection in ```Add a unit form``` then all corresponding dates of verticals are update

- When user choose a chapter in ```Add a unit form``` the chapters start date sets on start date filed. After that when he chooses a subsection the start and due date of subsection sets on start and due dates fields. Afterword when user unselect subsection by choosing ``All subsections`` then again chapters start date sets on start date field, due date field will be empty, Same for unit

- Add start date and due date validation for schedule tree. Now if user enters invalid start date or due date before start date, app will prompt error message.

- Sorted schedule tree on start date

@pdpinch @giocalitri @pwilkins 

#### Choosing chapter, subsection on ```Add a unit form```. 
![screen shot 2015-12-16 at 4 39 56 pm](https://cloud.githubusercontent.com/assets/10431250/11839942/b760df96-a413-11e5-9e7f-0c8c31a46121.png)
![screen shot 2015-12-16 at 4 40 04 pm](https://cloud.githubusercontent.com/assets/10431250/11839943/b762d47c-a413-11e5-90e2-f51d6c365d89.png)
![screen shot 2015-12-16 at 4 40 08 pm](https://cloud.githubusercontent.com/assets/10431250/11839944/b76f617e-a413-11e5-8a3b-aed006c34d3c.png)

#### Changing start date of a chapter.
![screen shot 2015-12-16 at 4 42 14 pm](https://cloud.githubusercontent.com/assets/10431250/11839984/099a806e-a414-11e5-87b1-a967b99b8965.png)
![screen shot 2015-12-16 at 4 42 30 pm](https://cloud.githubusercontent.com/assets/10431250/11839985/099b1718-a414-11e5-979e-b4d41490ed91.png)

#### changing dates of a subsection on ```Add a unit form``` changes corresponding dates of verticals aka units on schedule tree. 
![screen shot 2015-12-16 at 4 44 13 pm](https://cloud.githubusercontent.com/assets/10431250/11840028/4e4c9ae4-a414-11e5-9d79-558dcba56ab5.png)
![screen shot 2015-12-16 at 4 44 19 pm](https://cloud.githubusercontent.com/assets/10431250/11840030/4e5a2ac4-a414-11e5-8e0c-99bcdea6315e.png)
![screen shot 2015-12-16 at 4 44 28 pm](https://cloud.githubusercontent.com/assets/10431250/11840029/4e580276-a414-11e5-8c84-95e8bb967437.png)

#### Error message on invalid dates on schedule tree
![screen shot 2015-12-17 at 4 20 45 pm](https://cloud.githubusercontent.com/assets/10431250/11868593/ba6fd0d0-a4da-11e5-907f-a66d02466ee7.png)
![screen shot 2015-12-17 at 4 21 31 pm](https://cloud.githubusercontent.com/assets/10431250/11868594/ba78ce56-a4da-11e5-8d64-8f97588b92db.png)
![screen shot 2015-12-17 at 4 21 38 pm](https://cloud.githubusercontent.com/assets/10431250/11868595/ba7ac56c-a4da-11e5-8529-985ece7bdd5e.png)

#### Sorted schedule tree on start date.
![screen shot 2015-12-17 at 5 29 14 pm](https://cloud.githubusercontent.com/assets/10431250/11869764/eabfae28-a4e3-11e5-8d68-91d76d7c0300.png)
