### PR TITLE
Hid course registration from student in case of accessing ccx course direct

### DIFF
--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -1172,11 +1172,13 @@ class YouTubeQualityTest(VideoBaseTest):
 
         self.video.click_player_button('play')
 
+        self.video.wait_for(lambda: self.video.is_quality_button_visible, 'waiting for quality button to appear')
+
         self.assertFalse(self.video.is_quality_button_active)
 
         self.video.click_player_button('quality')
 
-        self.assertTrue(self.video.is_quality_button_active)
+        self.video.wait_for(lambda: self.video.is_quality_button_active, 'waiting for quality button activation')
 
 
 @attr('a11y')


### PR DESCRIPTION
### Background
fixes https://github.com/mitocw/edx-platform/issues/138

### What is done in this PR
**Studio Updates:** None.
**LMS Updates:** 
 - Hid CCX course registration from students. 
 - Now Only a coach can enroll students on CCX.
 - Students can not self-register for CCX.
 - If student tried to access CCX and he is not invited then he will be redirect to his dashboard.

@pdpinch @giocalitri 

- Student trying to access CCX. He will be redirected to dashboard.
![screen shot 2015-12-28 at 6 01 25 pm 2](https://cloud.githubusercontent.com/assets/10431250/12019157/6175ed36-ad8e-11e5-9ac1-ebc3c50d60d4.png)

![screen shot 2015-12-28 at 6 04 54 pm 2](https://cloud.githubusercontent.com/assets/10431250/12019158/6177801a-ad8e-11e5-8207-1a73db2c19f5.png)

- After coach enrolled him, he can access CCX
![screen shot 2015-12-28 at 6 05 16 pm](https://cloud.githubusercontent.com/assets/10431250/12019160/61786868-ad8e-11e5-82be-24eab05d9665.png)

![screen shot 2015-12-28 at 6 06 15 pm 2](https://cloud.githubusercontent.com/assets/10431250/12019159/6178487e-ad8e-11e5-8381-5916072a8533.png)