### PR TITLE
Allowed CCX coaches to see individual students progress from grade book

### DIFF
--- a/cms/static/js/models/chapter.js
+++ b/cms/static/js/models/chapter.js
@@ -1,4 +1,4 @@
-define(["backbone", "backbone.associations"], function(Backbone) {
+define(["backbone", "gettext", "backbone.associations"], function(Backbone, gettext) {
     var Chapter = Backbone.AssociatedModel.extend({
         defaults: function() {
             return {
@@ -32,17 +32,17 @@ define(["backbone", "backbone.associations"], function(Backbone) {
         validate: function(attrs, options) {
             if(!attrs.name && !attrs.asset_path) {
                 return {
-                    message: "Chapter name and asset_path are both required",
+                    message: gettext("Chapter name and asset_path are both required"),
                     attributes: {name: true, asset_path: true}
                 };
             } else if(!attrs.name) {
                 return {
-                    message: "Chapter name is required",
+                    message: gettext("Chapter name is required"),
                     attributes: {name: true}
                 };
             } else if (!attrs.asset_path) {
                 return {
-                    message: "asset_path is required",
+                    message: gettext("asset_path is required"),
                     attributes: {asset_path: true}
                 };
             }

--- a/cms/static/js/models/textbook.js
+++ b/cms/static/js/models/textbook.js
@@ -1,6 +1,6 @@
-define(["backbone", "underscore", "js/models/chapter", "js/collections/chapter",
+define(["backbone", "underscore", "gettext", "js/models/chapter", "js/collections/chapter",
         "backbone.associations", "coffee/src/main"],
-    function(Backbone, _, ChapterModel, ChapterCollection) {
+    function(Backbone, _, gettext, ChapterModel, ChapterCollection) {
 
     var Textbook = Backbone.AssociatedModel.extend({
         defaults: function() {
@@ -60,13 +60,13 @@ define(["backbone", "underscore", "js/models/chapter", "js/collections/chapter",
         validate: function(attrs, options) {
             if (!attrs.name) {
                 return {
-                    message: "Textbook name is required",
+                    message: gettext("Textbook name is required"),
                     attributes: {name: true}
                 };
             }
             if (attrs.chapters.length === 0) {
                 return {
-                    message: "Please add at least one chapter",
+                    message: gettext("Please add at least one chapter"),
                     attributes: {chapters: true}
                 };
             } else {
@@ -79,7 +79,7 @@ define(["backbone", "underscore", "js/models/chapter", "js/collections/chapter",
                 });
                 if(!_.isEmpty(invalidChapters)) {
                     return {
-                        message: "All chapters must have a name and asset",
+                        message: gettext("All chapters must have a name and asset"),
                         attributes: {chapters: invalidChapters}
                     };
                 }

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -94,7 +94,7 @@
             <div class="progress-fill"></div>
         </div>
         <div class="embeddable">
-            <label>URL:</label>
+            <label>${_('URL:')}</label>
             <input type="text" class="embeddable-xml-input" value='' readonly>
         </div>
         <form class="file-chooser" action="${asset_callback_url}"

--- a/cms/templates/course-create-rerun.html
+++ b/cms/templates/course-create-rerun.html
@@ -29,7 +29,7 @@ from django.template.defaultfilters import escapejs
       </h1>
 
       <nav class="nav-actions" aria-label="${_('Page Actions')}">
-        <h3 class="sr">Page Actions</h3>
+        <h3 class="sr">${_("Page Actions")}</h3>
         <ul>
           <li class="nav-item">
             <a href="" class="button cancel-button">${_("Cancel")}</a>

--- a/cms/templates/program_authoring.html
+++ b/cms/templates/program_authoring.html
@@ -14,5 +14,5 @@
 </%block>
 
 <%block name="content">
-    <div class="js-program-admin program-app layout-1q3q layout-reversed" data-home-url=${studio_home_url} data-lms-base-url=${lms_base_url} data-programs-api-url=${programs_api_url} data-auth-url=${programs_token_url}></div>
+    <div class="js-program-admin program-app layout-1q3q layout-reversed" data-home-url="${studio_home_url}" data-lms-base-url="${lms_base_url}" data-programs-api-url="${programs_api_url}" data-auth-url="${programs_token_url}" data-username="${request.user.username}"></div>
 </%block>

--- a/cms/templates/temp-course-landing.html
+++ b/cms/templates/temp-course-landing.html
@@ -7,17 +7,17 @@
 <div class="main-wrapper">
 	<article class="class-info">
 	<hgroup>
-		<h1>Circuits and Electronics</h1>
-		<h2>Massachusetts Institute of Technology</h2>
+		<h1>${_("Circuits and Electronics")}</h1>
+		<h2>${_("Massachusetts Institute of Technology")}</h2>
 	</hgroup>
 	<div class="log-in-form">
 		<form>
 			<div class="column">
-				<label>Email</label>
+				<label>${_("Email")}</label>
 				<input name="email" type="email" class="email-field" tabindex="1">
 			</div>
 			<div class="column">
-				<label>Password</label><a href="#" class="forgot-button">Forgot?</a>
+				<label>${_("Password")}</label><a href="#" class="forgot-button">${_("Forgot?")}</a>
 				<input name="password" type="password" class="password-field" tabindex="2">
 			</div>
 			<div class="column submit">
@@ -26,9 +26,9 @@
 		</form>
 	</div>
 	<div class="class-description">
-		<p>Ut laoreet dolore magna aliquam erat volutpat ut wisi enim ad minim veniam quis nostrud. Est usus legentis in iis qui, facit eorum claritatem Investigationes demonstraverunt lectores. Vel illum dolore eu feugiat nulla facilisis at vero eros, et accumsan et iusto? Te feugait nulla facilisi nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming! Et quinta decima eodem modo typi qui nunc nobis, videntur parum clari fiant sollemnes in? Diam nonummy nibh euismod tincidunt exerci tation ullamcorper, suscipit lobortis nisl ut aliquip ex? Nunc putamus parum, claram anteposuerit litterarum formas humanitatis per seacula quarta decima.</p>
-		<p>Gothica quam nunc putamus parum claram anteposuerit litterarum formas humanitatis per seacula. Facilisi nam liber tempor cum soluta nobis eleifend.</p>
-		<p><a href="#" class="sign-up-button">Sign Up</a></p>
+		<p>${_("Ut laoreet dolore magna aliquam erat volutpat ut wisi enim ad minim veniam quis nostrud. Est usus legentis in iis qui, facit eorum claritatem Investigationes demonstraverunt lectores. Vel illum dolore eu feugiat nulla facilisis at vero eros, et accumsan et iusto? Te feugait nulla facilisi nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming! Et quinta decima eodem modo typi qui nunc nobis, videntur parum clari fiant sollemnes in? Diam nonummy nibh euismod tincidunt exerci tation ullamcorper, suscipit lobortis nisl ut aliquip ex? Nunc putamus parum, claram anteposuerit litterarum formas humanitatis per seacula quarta decima.")}</p>
+		<p>${_("Gothica quam nunc putamus parum claram anteposuerit litterarum formas humanitatis per seacula. Facilisi nam liber tempor cum soluta nobis eleifend.")}</p>
+		<p><a href="#" class="sign-up-button">${_("Sign Up")}</a></p>
 	</div>
 	</article>
 	<footer>

--- a/lms/djangoapps/ccx/custom_exception.py
+++ b/lms/djangoapps/ccx/custom_exception.py
@@ -1,0 +1,17 @@
+"""
+This file has custom exceptions for ccx
+"""
+
+
+class CCXUserValidationException(Exception):
+    """
+    Custom Exception for validation of users in CCX
+    """
+    pass
+
+
+class CCXLocatorValidationException(Exception):
+    """
+    Custom Exception to validate CCX locator
+    """
+    pass

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -29,15 +29,9 @@ from student.roles import CourseCcxCoachRole
 
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx
+from lms.djangoapps.ccx.custom_exception import CCXUserValidationException
 
 log = logging.getLogger("edx.ccx")
-
-
-class CCXUserValidationException(Exception):
-    """
-    Custom Exception for validation of users in CCX
-    """
-    pass
 
 
 def get_ccx_from_ccx_locator(course_id):

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -3,12 +3,41 @@ CCX Enrollment operations for use by Coach APIs.
 
 Does not include any access control, be sure to check access before calling.
 """
+import datetime
 import logging
+import pytz
+
+from contextlib import contextmanager
+
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext as _
+from django.core.validators import validate_email
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+from courseware.courses import get_course_by_id
+from courseware.model_data import FieldDataCache
+from courseware.module_render import get_module_for_descriptor
+from instructor.enrollment import (
+    enroll_email,
+    unenroll_email,
+)
+from instructor.access import allow_access
+from instructor.views.tools import get_student_from_identifier
+from student.models import CourseEnrollment
+from student.roles import CourseCcxCoachRole
 
 from lms.djangoapps.ccx.models import CustomCourseForEdX
-
+from lms.djangoapps.ccx.overrides import get_override_for_ccx
 
 log = logging.getLogger("edx.ccx")
+
+
+class CCXUserValidationException(Exception):
+    """
+    Custom Exception for validation of users in CCX
+    """
+    pass
 
 
 def get_ccx_from_ccx_locator(course_id):
@@ -24,3 +53,206 @@ def get_ccx_from_ccx_locator(course_id):
         )
         return None
     return ccx[0]
+
+
+def get_date(ccx, node, date_type=None, parent_node=None):
+    """
+    This returns override or master date for section, subsection or a unit.
+
+    :param ccx: ccx instance
+    :param node: chapter, subsection or unit
+    :param date_type: start or due
+    :param parent_node: parent of node
+    :return: start or due date
+    """
+    date = get_override_for_ccx(ccx, node, date_type, None)
+    if date_type == "start":
+        master_date = node.start
+    else:
+        master_date = node.due
+
+    if date is not None:
+        # Setting override date [start or due]
+        date = date.strftime('%Y-%m-%d %H:%M')
+    elif not parent_node and master_date is not None:
+        # Setting date from master course
+        date = master_date.strftime('%Y-%m-%d %H:%M')
+    elif parent_node is not None:
+        # Set parent date (vertical has same dates as subsections)
+        date = get_date(ccx, node=parent_node, date_type=date_type)
+
+    return date
+
+
+def validate_date(year, month, day, hour, minute):
+    """
+    avoid corrupting db if bad dates come in
+    """
+    valid = True
+    if year < 0:
+        valid = False
+    if month < 1 or month > 12:
+        valid = False
+    if day < 1 or day > 31:
+        valid = False
+    if hour < 0 or hour > 23:
+        valid = False
+    if minute < 0 or minute > 59:
+        valid = False
+    return valid
+
+
+def parse_date(datestring):
+    """
+    Generate a UTC datetime.datetime object from a string of the form
+    'YYYY-MM-DD HH:MM'.  If string is empty or `None`, returns `None`.
+    """
+    if datestring:
+        date, time = datestring.split(' ')
+        year, month, day = map(int, date.split('-'))
+        hour, minute = map(int, time.split(':'))
+        if validate_date(year, month, day, hour, minute):
+            return datetime.datetime(
+                year, month, day, hour, minute, tzinfo=pytz.UTC)
+
+    return None
+
+
+def get_ccx_for_coach(course, coach):
+    """
+    Looks to see if user is coach of a CCX for this course.  Returns the CCX or
+    None.
+    """
+    ccxs = CustomCourseForEdX.objects.filter(
+        course_id=course.id,
+        coach=coach
+    )
+    # XXX: In the future, it would be nice to support more than one ccx per
+    # coach per course.  This is a place where that might happen.
+    if ccxs.exists():
+        return ccxs[0]
+    return None
+
+
+def get_valid_student_email(identifier):
+    """
+    Helper function to get an user email from an identifier and validate it.
+
+    In the UI a Coach can enroll users using both an email and an username.
+    This function takes care of:
+    - in case the identifier is an username, extracting the user object from
+        the DB and then the associated email
+    - validating the email
+
+    Arguments:
+        identifier (str): Username or email of the user to enroll
+
+    Returns:
+        str: A validated email for the user to enroll
+
+    Raises:
+        CCXUserValidationException: if the username is not found or the email
+            is not valid.
+    """
+    user = email = None
+    try:
+        user = get_student_from_identifier(identifier)
+    except User.DoesNotExist:
+        email = identifier
+    else:
+        email = user.email
+    try:
+        validate_email(email)
+    except ValidationError:
+        raise CCXUserValidationException('Could not find a user with name or email "{0}" '.format(identifier))
+    return email
+
+
+def ccx_students_enrolling_center(action, identifiers, email_students, course_key, email_params):
+    """
+    Function to enroll/add or unenroll/revoke students.
+
+    This function exists for backwards compatibility: in CCX there are
+    two different views to manage students that used to implement
+    a different logic. Now the logic has been reconciled at the point that
+    this function can be used by both.
+    The two different views can be merged after some UI refactoring.
+
+    Arguments:
+        action (str): type of action to perform (add, Enroll, revoke, Unenroll)
+        identifiers (list): list of students username/email
+        email_students (bool): Flag to send an email to students
+        course_key (CCXLocator): a CCX course key
+        email_params (dict): dictionary of settings for the email to be sent
+
+    Returns:
+        list: list of error
+    """
+    errors = []
+
+    if action == 'Enroll' or action == 'add':
+        ccx_course_overview = CourseOverview.get_from_id(course_key)
+        for identifier in identifiers:
+            if CourseEnrollment.objects.is_course_full(ccx_course_overview):
+                error = _('The course is full: the limit is {max_student_enrollments_allowed}').format(
+                    max_student_enrollments_allowed=ccx_course_overview.max_student_enrollments_allowed)
+                log.info("%s", error)
+                errors.append(error)
+                break
+            try:
+                email = get_valid_student_email(identifier)
+            except CCXUserValidationException as exp:
+                log.info("%s", exp)
+                errors.append("{0}".format(exp))
+                continue
+            enroll_email(course_key, email, auto_enroll=True, email_students=email_students, email_params=email_params)
+    elif action == 'Unenroll' or action == 'revoke':
+        for identifier in identifiers:
+            try:
+                email = get_valid_student_email(identifier)
+            except CCXUserValidationException as exp:
+                log.info("%s", exp)
+                errors.append("{0}".format(exp))
+                continue
+            unenroll_email(course_key, email, email_students=email_students, email_params=email_params)
+    return errors
+
+
+def prep_course_for_grading(course, request):
+    """Set up course module for overrides to function properly"""
+    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        course.id, request.user, course, depth=2)
+    course = get_module_for_descriptor(
+        request.user, request, course, field_data_cache, course.id, course=course
+    )
+
+    course._field_data_cache = {}  # pylint: disable=protected-access
+    course.set_grading_policy(course.grading_policy)
+
+
+@contextmanager
+def ccx_course(ccx_locator):
+    """Create a context in which the course identified by course_locator exists
+    """
+    course = get_course_by_id(ccx_locator)
+    yield course
+
+
+def assign_coach_role_to_ccx(ccx_locator, user, master_course_id):
+    """
+    Check if user has ccx_coach role on master course then assign him coach role on ccx only
+    if role is not already assigned. Because of this coach can open dashboard from master course
+    as well as ccx.
+    :param ccx_locator: CCX key
+    :param user: User to whom we want to assign role.
+    :param master_course_id: Master course key
+    """
+    coach_role_on_master_course = CourseCcxCoachRole(master_course_id)
+    # check if user has coach role on master course
+    if coach_role_on_master_course.has_user(user):
+        # Check if user has coach role on ccx.
+        role = CourseCcxCoachRole(ccx_locator)
+        if not role.has_user(user):
+            # assign user role coach on ccx
+            with ccx_course(ccx_locator) as course:
+                allow_access(course, user, "ccx_coach", send_email=False)

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -8,7 +8,6 @@ import json
 import logging
 import pytz
 
-from contextlib import contextmanager
 from copy import deepcopy
 from cStringIO import StringIO
 
@@ -19,8 +18,6 @@ from django.http import (
     HttpResponseForbidden,
 )
 from django.contrib import messages
-from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
 from django.db import transaction
 from django.http import Http404
 from django.shortcuts import redirect
@@ -33,19 +30,14 @@ from courseware.courses import get_course_by_id
 
 from courseware.field_overrides import disable_overrides
 from courseware.grades import iterate_grades_for
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module_for_descriptor
 from edxmako.shortcuts import render_to_response
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from ccx_keys.locator import CCXLocator
 from student.roles import CourseCcxCoachRole
 from student.models import CourseEnrollment
 
-from instructor.access import allow_access
 from instructor.views.api import _split_input_list
 from instructor.views.gradebook_api import get_grade_book_page
-from instructor.views.tools import get_student_from_identifier
 from instructor.enrollment import (
     enroll_email,
     unenroll_email,
@@ -59,16 +51,18 @@ from lms.djangoapps.ccx.overrides import (
     clear_ccx_field_info_from_ccx_map,
     bulk_delete_ccx_override_fields,
 )
+from lms.djangoapps.ccx.utils import (
+    assign_coach_role_to_ccx,
+    ccx_course,
+    ccx_students_enrolling_center,
+    get_ccx_for_coach,
+    get_date,
+    parse_date,
+    prep_course_for_grading,
+)
 
 log = logging.getLogger(__name__)
 TODAY = datetime.datetime.today  # for patching in tests
-
-
-class CCXUserValidationException(Exception):
-    """
-    Custom Exception for validation of users in CCX
-    """
-    pass
 
 
 def coach_dashboard(view):
@@ -218,26 +212,6 @@ def create_ccx(request, course, ccx=None):
     return redirect(url)
 
 
-def assign_coach_role_to_ccx(ccx_locator, user, master_course_id):
-    """
-    Check if user has ccx_coach role on master course then assign him coach role on ccx only
-    if role is not already assigned. Because of this coach can open dashboard from master course
-    as well as ccx.
-    :param ccx_locator: CCX key
-    :param user: User to whom we want to assign role.
-    :param master_course_id: Master course key
-    """
-    coach_role_on_master_course = CourseCcxCoachRole(master_course_id)
-    # check if user has coach role on master course
-    if coach_role_on_master_course.has_user(user):
-        # Check if user has coach role on ccx.
-        role = CourseCcxCoachRole(ccx_locator)
-        if not role.has_user(user):
-            # assign user role coach on ccx
-            with ccx_course(ccx_locator) as course:
-                allow_access(course, user, "ccx_coach", send_email=False)
-
-
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
@@ -354,85 +328,6 @@ def set_grading_policy(request, course, ccx=None):
     return redirect(url)
 
 
-def validate_date(year, month, day, hour, minute):
-    """
-    avoid corrupting db if bad dates come in
-    """
-    valid = True
-    if year < 0:
-        valid = False
-    if month < 1 or month > 12:
-        valid = False
-    if day < 1 or day > 31:
-        valid = False
-    if hour < 0 or hour > 23:
-        valid = False
-    if minute < 0 or minute > 59:
-        valid = False
-    return valid
-
-
-def parse_date(datestring):
-    """
-    Generate a UTC datetime.datetime object from a string of the form
-    'YYYY-MM-DD HH:MM'.  If string is empty or `None`, returns `None`.
-    """
-    if datestring:
-        date, time = datestring.split(' ')
-        year, month, day = map(int, date.split('-'))
-        hour, minute = map(int, time.split(':'))
-        if validate_date(year, month, day, hour, minute):
-            return datetime.datetime(
-                year, month, day, hour, minute, tzinfo=pytz.UTC)
-
-    return None
-
-
-def get_ccx_for_coach(course, coach):
-    """
-    Looks to see if user is coach of a CCX for this course.  Returns the CCX or
-    None.
-    """
-    ccxs = CustomCourseForEdX.objects.filter(
-        course_id=course.id,
-        coach=coach
-    )
-    # XXX: In the future, it would be nice to support more than one ccx per
-    # coach per course.  This is a place where that might happen.
-    if ccxs.exists():
-        return ccxs[0]
-    return None
-
-
-def get_date(ccx, node, date_type=None, parent_node=None):
-    """
-    This returns override or master date for section, subsection or a unit.
-
-    :param ccx: ccx instance
-    :param node: chapter, subsection or unit
-    :param date_type: start or due
-    :param parent_node: parent of node
-    :return: start or due date
-    """
-    date = get_override_for_ccx(ccx, node, date_type, None)
-    if date_type == "start":
-        master_date = node.start
-    else:
-        master_date = node.due
-
-    if date is not None:
-        # Setting override date [start or due]
-        date = date.strftime('%Y-%m-%d %H:%M')
-    elif not parent_node and master_date is not None:
-        # Setting date from master course
-        date = master_date.strftime('%Y-%m-%d %H:%M')
-    elif parent_node is not None:
-        # Set parent date (vertical has same dates as subsections)
-        date = get_date(ccx, node=parent_node, date_type=date_type)
-
-    return date
-
-
 def get_ccx_schedule(course, ccx):
     """
     Generate a JSON serializable CCX schedule.
@@ -515,90 +410,6 @@ def ccx_schedule(request, course, ccx=None):  # pylint: disable=unused-argument
     return HttpResponse(json_schedule, content_type='application/json')
 
 
-def get_valid_student_email(identifier):
-    """
-    Helper function to get an user email from an identifier and validate it.
-
-    In the UI a Coach can enroll users using both an email and an username.
-    This function takes care of:
-    - in case the identifier is an username, extracting the user object from
-        the DB and then the associated email
-    - validating the email
-
-    Arguments:
-        identifier (str): Username or email of the user to enroll
-
-    Returns:
-        str: A validated email for the user to enroll
-
-    Raises:
-        CCXUserValidationException: if the username is not found or the email
-            is not valid.
-    """
-    user = email = None
-    try:
-        user = get_student_from_identifier(identifier)
-    except User.DoesNotExist:
-        email = identifier
-    else:
-        email = user.email
-    try:
-        validate_email(email)
-    except ValidationError:
-        raise CCXUserValidationException('Could not find a user with name or email "{0}" '.format(identifier))
-    return email
-
-
-def _ccx_students_enrrolling_center(action, identifiers, email_students, course_key, email_params):
-    """
-    Function to enroll/add or unenroll/revoke students.
-
-    This function exists for backwards compatibility: in CCX there are
-    two different views to manage students that used to implement
-    a different logic. Now the logic has been reconciled at the point that
-    this function can be used by both.
-    The two different views can be merged after some UI refactoring.
-
-    Arguments:
-        action (str): type of action to perform (add, Enroll, revoke, Unenroll)
-        identifiers (list): list of students username/email
-        email_students (bool): Flag to send an email to students
-        course_key (CCXLocator): a CCX course key
-        email_params (dict): dictionary of settings for the email to be sent
-
-    Returns:
-        list: list of error
-    """
-    errors = []
-
-    if action == 'Enroll' or action == 'add':
-        ccx_course_overview = CourseOverview.get_from_id(course_key)
-        for identifier in identifiers:
-            if CourseEnrollment.objects.is_course_full(ccx_course_overview):
-                error = ('The course is full: the limit is {0}'.format(
-                    ccx_course_overview.max_student_enrollments_allowed))
-                log.info("%s", error)
-                errors.append(error)
-                break
-            try:
-                email = get_valid_student_email(identifier)
-            except CCXUserValidationException as exp:
-                log.info("%s", exp)
-                errors.append("{0}".format(exp))
-                continue
-            enroll_email(course_key, email, auto_enroll=True, email_students=email_students, email_params=email_params)
-    elif action == 'Unenroll' or action == 'revoke':
-        for identifier in identifiers:
-            try:
-                email = get_valid_student_email(identifier)
-            except CCXUserValidationException as exp:
-                log.info("%s", exp)
-                errors.append("{0}".format(exp))
-                continue
-            unenroll_email(course_key, email, email_students=email_students, email_params=email_params)
-    return errors
-
-
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
@@ -616,7 +427,7 @@ def ccx_invite(request, course, ccx=None):
     course_key = CCXLocator.from_course_locator(course.id, ccx.id)
     email_params = get_email_params(course, auto_enroll=True, course_key=course_key, display_name=ccx.display_name)
 
-    _ccx_students_enrrolling_center(action, identifiers, email_students, course_key, email_params)
+    ccx_students_enrolling_center(action, identifiers, email_students, course_key, email_params)
 
     url = reverse('ccx_coach_dashboard', kwargs={'course_id': course_key})
     return redirect(url)
@@ -639,33 +450,13 @@ def ccx_student_management(request, course, ccx=None):
     course_key = CCXLocator.from_course_locator(course.id, ccx.id)
     email_params = get_email_params(course, auto_enroll=True, course_key=course_key, display_name=ccx.display_name)
 
-    errors = _ccx_students_enrrolling_center(action, identifiers, email_students, course_key, email_params)
+    errors = ccx_students_enrolling_center(action, identifiers, email_students, course_key, email_params)
 
     for error_message in errors:
         messages.error(request, error_message)
 
     url = reverse('ccx_coach_dashboard', kwargs={'course_id': course_key})
     return redirect(url)
-
-
-@contextmanager
-def ccx_course(ccx_locator):
-    """Create a context in which the course identified by course_locator exists
-    """
-    course = get_course_by_id(ccx_locator)
-    yield course
-
-
-def prep_course_for_grading(course, request):
-    """Set up course module for overrides to function properly"""
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
-        course.id, request.user, course, depth=2)
-    course = get_module_for_descriptor(
-        request.user, request, course, field_data_cache, course.id, course=course
-    )
-
-    course._field_data_cache = {}  # pylint: disable=protected-access
-    course.set_grading_policy(course.grading_policy)
 
 
 # Grades can potentially be written - if so, let grading manage the transaction.

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -33,7 +33,7 @@ from rest_framework import status
 import newrelic.agent
 
 from courseware import grades
-from courseware.access import has_access, _adjust_start_date_for_beta_testers
+from courseware.access import has_access, has_ccx_coach_role, _adjust_start_date_for_beta_testers
 from courseware.access_response import StartDateError
 from courseware.access_utils import in_preview_mode
 from courseware.courses import (
@@ -97,6 +97,7 @@ from util.views import ensure_valid_course_key
 from eventtracking import tracker
 import analytics
 from courseware.url_helpers import get_redirect_url
+from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 
 from lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
@@ -918,7 +919,7 @@ def course_about(request, course_id):
 def progress(request, course_id, student_id=None):
     """ Display the progress page. """
 
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course_key = CourseKey.from_string(course_id)
 
     with modulestore().bulk_operations(course_key):
         return _progress(request, course_key, student_id)
@@ -940,13 +941,19 @@ def _progress(request, course_key, student_id):
         return redirect(reverse('course_survey', args=[unicode(course.id)]))
 
     staff_access = bool(has_access(request.user, 'staff', course))
+    try:
+        coach_access = has_ccx_coach_role(request.user, course_key)
+    except CCXLocatorValidationException:
+        coach_access = False
+
+    has_access_on_students_profiles = staff_access or coach_access
 
     if student_id is None or student_id == request.user.id:
         # always allowed to see your own profile
         student = request.user
     else:
         # Requesting access to a different student's profile
-        if not staff_access:
+        if not has_access_on_students_profiles:
             raise Http404
         try:
             student = User.objects.get(id=student_id)

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -170,17 +170,16 @@ FEATURES['CERTIFICATES_HTML_VIEW'] = True
 
 
 ########################## Course Discovery #######################
-_ = lambda s: s
-LANGUAGE_MAP = {'terms': {lang: display for lang, display in ALL_LANGUAGES}, 'name': _('Language')}
+LANGUAGE_MAP = {'terms': {lang: display for lang, display in ALL_LANGUAGES}, 'name': 'Language'}
 COURSE_DISCOVERY_MEANINGS = {
     'org': {
-        'name': _('Organization'),
+        'name': 'Organization',
     },
     'modes': {
-        'name': _('Course Type'),
+        'name': 'Course Type',
         'terms': {
-            'honor': _('Honor'),
-            'verified': _('Verified'),
+            'honor': 'Honor',
+            'verified': 'Verified',
         },
     },
     'language': LANGUAGE_MAP,

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -7,7 +7,6 @@ import third_party_auth
 from third_party_auth import pipeline
 from microsite_configuration import microsite
 from django.core.urlresolvers import reverse
-from microsite_configuration import microsite
 import json
 %>
 

--- a/lms/templates/shoppingcart/shopping_cart.html
+++ b/lms/templates/shoppingcart/shopping_cart.html
@@ -108,11 +108,11 @@ from openedx.core.lib.courses import course_image_url
                   </div>
                   <button class="inc button" data-operation="inc">
                     <i class="icon fa fa-caret-up" aria-hidden="true"><span>+</span></i>
-                    <span class="sr">Increase</span>
+                    <span class="sr">${_('Increase')}</span>
                   </button>
                   <button class="dec button" data-operation="dec">
                     <i class="icon fa fa-caret-down"></i>
-                    <span class="sr">Decrease</span>
+                    <span class="sr">${_('Decrease')}</span>
                   </button>
                       <!--<a name="updateBtn" class="updateBtn hidden" id="updateBtn-${item.id}" href="#">update</a>-->
                   <span class="error-text hidden" id="students-${item.id}"></span>
@@ -122,7 +122,7 @@ from openedx.core.lib.courses import course_image_url
               <div class="col-3">
                  <button href="#" class="btn-remove" data-item-id="${item.id}">
                   <i class="icon fa fa-times-circle" aria-hidden="true"></i>
-                  <span class="sr">Remove</span>
+                  <span class="sr">${_('Remove')}</span>
                 </button>
               </div>
           </div>
@@ -136,7 +136,7 @@ from openedx.core.lib.courses import course_image_url
             <div class="code-text">
             % if not discount_applied:
               <div class="code-input" aria-live="polite">
-                <label for="input_code" class="sr">Discount or activation code</label>
+                <label for="input_code" class="sr">${_('Discount or activation code')}</label>
                 <input type="text" placeholder="${_('discount or activation code')}" id="input_code">
                 <button type="submit" class="blue" id="submit-code">${_('Apply')}</button>
                 <span class="error-text hidden" id="code"></span>


### PR DESCRIPTION
### Background
https://github.com/mitocw/edx-platform/issues/88

### What is done in this PR
**Studio Updates:** None.
**LMS Updates:** 
 - Coach can open grade book and click on student name to see his progress on CCX.
 
@pdpinch @giocalitri 

- Enrollment tab on coach dashboard.
![screen shot 2015-12-29 at 5 32 23 pm](https://cloud.githubusercontent.com/assets/10431250/12034462/0d2b9e36-ae53-11e5-90ab-983fb7b640ed.png)

- Coach can open grade book from Student Admin tab from his dashboard
![screen shot 2015-12-29 at 5 32 33 pm](https://cloud.githubusercontent.com/assets/10431250/12034440/db7a8794-ae52-11e5-8546-37f93b8f536b.png)

- On grade book coach can click on student name to see his progress.
![screen shot 2015-12-29 at 5 32 40 pm](https://cloud.githubusercontent.com/assets/10431250/12034441/db7f5f08-ae52-11e5-8ae4-01a518a8bdb5.png)