### PR TITLE
Fixed calculation of max_pts for problems which are not attempted yet

### DIFF
--- a/lms/templates/courseware/legacy_instructor_dashboard.html
+++ b/lms/templates/courseware/legacy_instructor_dashboard.html
@@ -240,7 +240,9 @@ function goto( mode)
     <br/>
     <br/>
     </li>
-    <li>${_("Assignment name:")} <input type="text" name="assignment_name" size=40 >
+    <li>${_("Assignment name:")} <input type="text" name="assignment_name" size=40 > <input
+        type="checkbox" name="normalize_grades" id="normalize_grades" checked="checked" /> <label style="display:inline"
+              for="normalize_grades">${_("Normalize Grades")}</label>
     <br/>
     <br/>
     <input type="submit" name="action" value="Display grades for assignment">


### PR DESCRIPTION
### Background
connected to https://github.com/mitocw/edx-platform/pull/190
- In existing code while calculating grades if your did not attempt problem then courseware set his grades like ``graded_total = Score(0.0, 1.0, True, section_name, None)``
https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/grades.py#L461
- This case an issue when we show non-normalize data on legacy dashboard. In this case the grades of students appear like ``score/max-score`` and for students who did not attempted the same problem the score will be ```0/1```. 
- ``0/1`` looks like normalize grade, and whole grade sheet look like mixture of normalize and non-normalize grades.

![screen shot 2016-02-03 at 5 04 32 pm](https://cloud.githubusercontent.com/assets/10431250/12781772/3fc4b52e-ca98-11e5-9d79-4a8203a0e7cd.png)

### What is done in this PR
**Studio Updates:** None
**LMS Updates:**
- Now grades of problems which are not attempted will be ``0/max score``.

cc @pdpinch @pwilkins 
@pdpinch  as we discussed yesterday. you told me to create Pr for ormsbee. So that you can discuss with him.

##### After solution:

- **Not Normalize**
![screen shot 2016-02-03 at 4 43 16 pm](https://cloud.githubusercontent.com/assets/10431250/12781736/0969c884-ca98-11e5-8bcd-e5acfd490f33.png)

- **Normalize**
![screen shot 2016-02-03 at 4 42 54 pm](https://cloud.githubusercontent.com/assets/10431250/12781748/166107fa-ca98-11e5-9f4c-37998d773edd.png)




