### PR TITLE
Added visible_to_staff_only field to course blocks API

### DIFF
--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -77,3 +77,27 @@ class TestGetBlocks(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
                 self.assertIn(unicode(block.location), blocks['blocks'])
             else:
                 self.assertNotIn(unicode(block.location), blocks['blocks'])
+
+    def test_visible_to_staff_only(self):
+        """
+        Assert that visible_to_staff_only works as a requested_field
+        """
+        # Update user factory to have staff access
+        self.user = UserFactory.create(is_staff=True)
+        self.request = RequestFactory().get("/dummy")
+        self.request.user = self.user
+
+        # self.course.visible_to_staff_only is False
+        blocks = get_blocks(self.request, self.course.location, self.user, requested_fields=['visible_to_staff_only'])
+        block = blocks['blocks'][blocks['root']]
+        self.assertFalse(block['visible_to_staff_only'])
+
+        # self.html_block.visible_to_staff_only was set to True in setUpClass
+        blocks = get_blocks(self.request, self.html_block.location, self.user, requested_fields=['visible_to_staff_only'])
+        block = blocks['blocks'][blocks['root']]
+        self.assertTrue(block['visible_to_staff_only'])
+
+        # Not there by default
+        blocks = get_blocks(self.request, self.html_block.location, self.user)
+        block = blocks['blocks'][blocks['root']]
+        self.assertNotIn('visible_to_staff_only', block)

--- a/lms/djangoapps/course_api/blocks/transformers/__init__.py
+++ b/lms/djangoapps/course_api/blocks/transformers/__init__.py
@@ -5,6 +5,7 @@ Course API Block Transformers
 from .student_view import StudentViewTransformer
 from .block_counts import BlockCountsTransformer
 from .navigation import BlockNavigationTransformer
+from lms.djangoapps.course_blocks.transformers.visibility import VisibilityTransformer
 
 
 class SupportedFieldType(object):
@@ -50,5 +51,13 @@ SUPPORTED_FIELDS = [
         BlockNavigationTransformer,
         requested_field_name='nav_depth',
         serializer_field_name='descendants',
+    ),
+
+    # Provide the staff visibility info stored when VisibilityTransformer ran previously
+    SupportedFieldType(
+        'merged_visible_to_staff_only',
+        VisibilityTransformer,
+        requested_field_name='visible_to_staff_only',
+        serializer_field_name='visible_to_staff_only',
     )
 ]


### PR DESCRIPTION
Fixes #211

This PR adds an optional field `visible_to_staff_only` to the course blocks API in LMS at `/api/courses/v1/blocks/`. The new field is not present by default but it can be enabled by adding the field to `requested_fields`. Example URL: http://localhost:8000/api/courses/v1/blocks/?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course&all_blocks=1&requested_fields=visible_to_staff_only&depth=all

This change is useful to us at MIT ODL because it allows us to filter out chapters for courses which have been marked as hidden. The CCXCon application will have staff access for certain courses and it needs to be able to hide from the user chapters which are not available for use by students.

This uses the existing `VisibilityTransformer` transformer which already marks blocks with the `merged_visible_to_staff_only` attribute. This PR just exposes that value in the API and adds tests for its functionality.

Manual testing: it should be enough to adjust the example URL listed above to view the course blocks API in your local openedX instance. You should see the new `visible_to_staff_only` field for each block listed with a true or false value.
