### PR TITLE
[Legacy dashboard] Fixed 500 error in case of invalid progress summery for student(s) gradebook

### DIFF
--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -793,6 +793,8 @@ def get_student_grade_summary_data(
                 else:
                     category_cnts = Counter()
                     progress_summary = grades._progress_summary(student, request, course)
+                    if not progress_summary:
+                        continue
                     for grade_item in gradeset['section_breakdown']:
                         category = grade_item['category']
                         try:


### PR DESCRIPTION
Hi,

In this PR I fixed an issue in ``Grades`` in legacy dashboard where if it throws 500 error when we get progress summery of invalid student.

Now we are omitting grade calculation for invalid students.

@pdpinch @bdero 