### PR TITLE
Fixed 500 error in case of user's profile not found when login/logout with CAS

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1602,8 +1602,8 @@ def enforce_single_login(sender, request, user, signal, **kwargs):    # pylint: 
         else:
             key = None
         if user:
-            if not UserProfile.objects.filter(user=user):
-                # if user's profile is not set then create it
+            if not UserProfile.objects.filter(user=user).exists():
+                # if user has not profile then create it.
                 user_profile = UserProfile(name=user.username, user=user)
                 user_profile.save()
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1602,6 +1602,11 @@ def enforce_single_login(sender, request, user, signal, **kwargs):    # pylint: 
         else:
             key = None
         if user:
+            if not UserProfile.objects.filter(user=user):
+                # if user's profile is not set then create it
+                user_profile = UserProfile(name=user.username, user=user)
+                user_profile.save()
+
             user.profile.set_login_session(key)
 
 

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -273,6 +273,11 @@ class LoginTest(TestCase):
 
     @patch.dict("django.conf.settings.FEATURES", {'PREVENT_CONCURRENT_LOGINS': True})
     def test_single_session_with_no_user_profile(self):
+        """
+        Assert that user login with cas (Central Authentication Service) is
+        redirect to dashboard in case of lms or upload_transcripts in case of
+        cms
+        """
         user = UserFactory.build(username='tester', email='tester@edx.org')
         user.set_password('test_password')
         user.save()

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -282,16 +282,21 @@ class LoginTest(TestCase):
         user.set_password('test_password')
         user.save()
 
-        creds = {'email': 'test@edx.org', 'password': 'test_password'}
+        creds = {'email': 'tester@edx.org', 'password': 'test_password'}
         client1 = Client()
         client2 = Client()
+
+        # Assert that no profile is created.
+        self.assertFalse(hasattr(user, 'profile'))
 
         response = client1.post(self.url, creds)
         self._assert_response(response, success=True)
 
         # Reload the user from the database
         user = UserFactory.FACTORY_FOR.objects.get(pk=user.pk)
-        self.assertFalse(hasattr(user, 'profile'))
+
+        # assert profile is created.
+        self.assertTrue(hasattr(user, 'profile'))
 
         # second login should log out the first
         response = client2.post(self.url, creds)


### PR DESCRIPTION
fixes  https://github.com/mitocw/edx-platform/issues/102
There was an [exception](https://gist.github.com/pdpinch/bd2e626df27a0ccad194#file-gistfile1-txt-L16) because of user's profile was not created on the time of login int edX platform using cas for first time.

@pdpinch @bdero 