### PR TITLE
Hide coaches/staff/instructors from coach's enrollment tab, gradebook, grades csv file

### DIFF
--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -463,3 +463,23 @@ def remove_master_course_staff_from_ccx(master_course, ccx_key, display_name, se
                     email_students=send_email,
                     email_params=email_params,
                 )
+
+
+def list_course_members(course_id):
+    """
+    Returns list of students enroll in course/ccx excluding staff, instructors and coaches on master course.
+
+    Args:
+        course_id (CourseLocator): the course key
+
+    """
+    course_locator = course_id
+    if getattr(course_id, 'ccx', None):
+        course_locator = course_id.to_course_locator()
+
+    staff = CourseStaffRole(course_locator).users_with_role()
+    admins = CourseInstructorRole(course_locator).users_with_role()
+    coaches = CourseCcxCoachRole(course_locator).users_with_role()
+
+    query_set = CourseEnrollment.objects.filter(course_id=course_id, is_active=True)
+    return query_set.exclude(user__in=staff).exclude(user__in=admins).exclude(user__in=coaches)

--- a/lms/djangoapps/instructor/views/gradebook_api.py
+++ b/lms/djangoapps/instructor/views/gradebook_api.py
@@ -64,7 +64,7 @@ def calculate_page_info(offset, total_students):
     }
 
 
-def get_grade_book_page(request, course, course_key):
+def get_grade_book_page(request, course, course_key, exclude=None):
     """
     Get student records per page along with page information i.e current page, total pages and
     offset information.
@@ -75,6 +75,10 @@ def get_grade_book_page(request, course, course_key):
         courseenrollment__course_id=course_key,
         courseenrollment__is_active=1
     ).order_by('username').select_related("profile")
+
+    if exclude:
+        for __, list in exclude.items():
+            enrolled_students = enrolled_students.exclude(username__in=list)
 
     total_students = enrolled_students.count()
     page = calculate_page_info(current_offset, total_students)


### PR DESCRIPTION
### Background
Fixes https://github.com/mitocw/edx-platform/issues/243

### What is done in this PR
**Studio Updates:** None.
**LMS Updates:** 
- Now showing ccx members in coach enrollment tab exculding staff, instructor and coach on master course.
- Hid staff, instructors and coach from gradebook
- Hid staff, instructors and coach from gradebook csv file

@pdpinch @giocalitri 

### To test:
- Create a course
- Add staff, instructors and coaches to the course.
- Create CCX
- See enrollment page in coach dashboard their should be no staff and instructors
- Open gradebook and see list of student make sure their are no staff, instructors and coaches
- Download gradebook csv and check their should no staff, instructors and coaches of master course 

