### PR TITLE
Danial/ede 338 make common problems public

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -1138,6 +1138,10 @@ div.problem {
       // the notification does not grow in height.
       margin-bottom: 8px;
 
+      .signin-link {
+        text-decoration: underline;
+      }
+
       ol {
         list-style: none outside none;
         padding: 0;

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -465,13 +465,6 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             item_type = item.get_icon_class()
             usage_id = item.scope_ids.usage_id
 
-            if item_type == 'problem' and not is_user_authenticated:
-                log.info(
-                    'Problem [%s] was not rendered because anonymous access is not allowed for graded content',
-                    usage_id
-                )
-                continue
-
             show_bookmark_button = False
             is_bookmarked = False
 

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -5,6 +5,8 @@ import time
 import yaml
 
 from contracts import contract, new_contract
+from django.urls import reverse
+from django.utils.http import urlquote_plus
 from functools import partial
 from lxml import etree
 from collections import namedtuple
@@ -38,7 +40,7 @@ from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.asides import AsideUsageKeyV2, AsideDefinitionKeyV2
 from xmodule.exceptions import UndefinedContext
 
-from openedx.core.djangolib.markup import HTML
+from openedx.core.djangolib.markup import HTML, Text
 
 log = logging.getLogger(__name__)
 
@@ -72,11 +74,6 @@ STUDIO_VIEW = 'studio_view'
 # Views that present a "preview" view of an xblock (as opposed to an editing view).
 PREVIEW_VIEWS = [STUDENT_VIEW, PUBLIC_VIEW, AUTHOR_VIEW]
 
-DEFAULT_PUBLIC_VIEW_MESSAGE = (
-    u'This content is only accessible to enrolled learners. '
-    u'Sign in or register, and enroll in this course to view it.'
-)
-
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
@@ -86,6 +83,7 @@ class OpaqueKeyReader(IdReader):
     """
     IdReader for :class:`DefinitionKey` and :class:`UsageKey`s.
     """
+
     def get_definition_id(self, usage_id):
         """Retrieve the definition that a usage is derived from.
 
@@ -163,6 +161,7 @@ class AsideKeyGenerator(IdGenerator):
     """
     An :class:`.IdGenerator` that only provides facilities for constructing new XBlockAsides.
     """
+
     def create_aside(self, definition_id, usage_id, aside_type):
         """
         Make a new aside definition and usage ids, indicating an :class:`.XBlockAside` of type `aside_type`
@@ -770,15 +769,34 @@ class XModuleMixin(XModuleFields, XBlock):
             u'<div class="message-content">{}</div></div></div>'
         )
 
-        if self.display_name:
-            display_text = _(
-                u'{display_name} is only accessible to enrolled learners. '
-                'Sign in or register, and enroll in this course to view it.'
-            ).format(
-                display_name=self.display_name
-            )
-        else:
-            display_text = _(DEFAULT_PUBLIC_VIEW_MESSAGE)
+        next_url = urlquote_plus(reverse('course_root', kwargs={
+            'course_id': self.location.course_key,
+        }))
+
+        link_start = lambda url: HTML(u'<a href={url}>'.format(url=url))
+        link_end = HTML(u'</a>')
+
+        with_next_url = lambda url: u'{url}?next={next_url}'.format(
+            url=url,
+            next_url=next_url
+        )
+
+        display_text = _(
+            u'{display_name} is only accessible to enrolled learners. '
+            u'{sign_in_link_start}Sign in{sign_in_link_end} or '
+            u'{register_link_start}register{register_link_end}, '
+            u'and enroll in this course to view it.'
+        )
+
+        dispaly_name = self.display_name or 'This content'
+
+        display_text = Text(display_text).format(
+            display_name=dispaly_name,
+            sign_in_link_start=link_start(with_next_url(reverse('signin_user'))),
+            sign_in_link_end=link_end,
+            register_link_start=link_start(with_next_url(reverse('register_user'))),
+            register_link_end=link_end
+        )
 
         return Fragment(alert_html.format(display_text))
 
@@ -805,6 +823,7 @@ class ProxyAttribute(object):
     del bar.foo_attr
     assert not hasattr(bar.foo, 'foo_attr')
     """
+
     def __init__(self, source, name):
         """
         :param source: The name of the attribute to proxy to
@@ -900,6 +919,7 @@ class XModule(HTMLSnippet, XModuleMixin):
             name, so we carry the FieldStorage .filename attribute as the .name.
 
             """
+
             def __init__(self, webob_file):
                 self.file = webob_file.file
                 self.name = webob_file.filename
@@ -1261,6 +1281,7 @@ class ConfigurableFragmentWrapper(object):
     """
     Runtime mixin that allows for composition of many `wrap_xblock` wrappers
     """
+
     def __init__(self, wrappers=None, wrappers_asides=None, **kwargs):
         """
         :param wrappers: A list of wrappers, where each wrapper is:
@@ -1394,6 +1415,7 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):
     Base class for :class:`Runtime`s to be used with :class:`XModuleDescriptor`s
     """
     # pylint: disable=bad-continuation
+
     def __init__(
         self, load_item, resources_fs, error_tracker, get_policy=None, disabled_xblock_types=lambda: [], **kwargs
     ):
@@ -1986,6 +2008,7 @@ class CombinedSystem(object):
 
 class DoNothingCache(object):
     """A duck-compatible object to use in ModuleSystem when there's no cache."""
+
     def get(self, _key):
         return None
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -331,6 +331,18 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         response = self.client.post(dispatch_url, {'position': 2})
         self.assertEquals(403, response.status_code)
 
+    @patch(
+        'lms.djangoapps.courseware.module_render.COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled', return_value=True
+    )
+    def test_anonymous_post_xblock_callback_with_public_access_enabled(self, _):
+        """
+        Test that anonymous POST is allowed if public access to
+        the course is enabled.
+        """
+        dispatch_url = self._get_dispatch_url()
+        response = self.client.post(dispatch_url, {'position': 2})
+        self.assertEquals(200, response.status_code)
+
     def test_session_authentication(self):
         """ Test that the xblock endpoint supports session authentication."""
         self.client.login(username=self.mock_user.username, password="test")
@@ -968,6 +980,7 @@ class TestXBlockView(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 @ddt.ddt
 class TestTOC(ModuleStoreTestCase):
     """Check the Table of Contents for a course"""
+
     def setup_request_and_course(self, num_finds, num_sends):
         """
         Sets up the toy course in the modulestore and the request object.
@@ -1080,6 +1093,7 @@ class TestProctoringRendering(SharedModuleStoreTestCase):
         cls.course_key = ToyCourseFactory.create().id
 
     """Check the Table of Contents for a course"""
+
     def setUp(self):
         """
         Set up the initial mongo datastores
@@ -1421,6 +1435,7 @@ class TestGatedSubsectionRendering(SharedModuleStoreTestCase, MilestonesTestCase
     """
     Test the toc for a course is rendered correctly when there is gated content
     """
+
     def setUp(self):
         """
         Set up the initial test data
@@ -1498,6 +1513,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
     Tests to verify that standard modifications to the output of XModule/XBlock
     student_view are taking place
     """
+
     def setUp(self):
         super(TestHtmlModifiers, self).setUp()
         self.course = CourseFactory.create()
@@ -1793,6 +1809,7 @@ class DetachedXBlock(XBlock):
     """
     XBlock marked with the 'detached' flag.
     """
+
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """
         A simple view that returns just enough to test.
@@ -2226,6 +2243,7 @@ class TestRebindModule(TestSubmittingProblems):
     Tests to verify the functionality of rebinding a module.
     Inherit from TestSubmittingProblems to get functionality that set up a course structure
     """
+
     def setUp(self):
         super(TestRebindModule, self).setUp()
         self.homework = self.add_graded_section_to_course('homework')
@@ -2588,6 +2606,7 @@ class TestDisabledXBlockTypes(ModuleStoreTestCase):
     """
     Tests that verify disabled XBlock types are not loaded.
     """
+
     def setUp(self):
         super(TestDisabledXBlockTypes, self).setUp()
         XBlockConfiguration(name='video', enabled=False).save()

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -318,7 +318,13 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
             )
             self.assertContains(response, '<div class="user-messages"', count=(1 if expected_enroll_message else 0))
             if expected_enroll_message:
-                self.assertContains(response, 'You must be enrolled in the course to see course content.')
+                if (
+                    enable_unenrolled_access and
+                    is_anonymous
+                ):
+                    self.assertContains(response, 'ask questions to the community, and more!')
+                else:
+                    self.assertContains(response, 'You must be enrolled in the course to see course content.')
 
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)


### PR DESCRIPTION
### Description
By default, edX allows public access to non-problem xBlocks. This PR adds the public access for Capa problems (Common Problems) provided by Open edX.

Message on course outline page for public courses is also updated
![image](https://user-images.githubusercontent.com/42166091/78357438-ec81e200-75ca-11ea-9864-c0458a04427e.png)

### How to test
- Make a course (or use an existing one) (https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_public_course.html)
- Add problems in units
- Enable public access on the course
- Try to access and interact with problems while being an anonymous user.

### How to run unit tests
```
paver test_system -s lms -t lms/djangoapps/courseware/tests/test_module_render.py::ModuleRenderTestCase::test_anonymous_post_xblock_callback_with_public_access_enabled

paver test_system -s lms -t common/lib/xmodule/xmodule/tests/test_capa_module.py::CapaModuleTest::test_public_view

paver test_system -s lms -t common/lib/xmodule/xmodule/tests/test_capa_module.py::CapaModuleTest::test_submit_problem_with_authenticated_user

paver test_system -s lms -t common/lib/xmodule/xmodule/tests/test_capa_module.py::CapaModuleTest::test_submit_problem_with_anonymous_user

paver test_system -s lms -t common/lib/xmodule/xmodule/tests/test_capa_module.py::CapaModuleTest::test_save_problem_with_anonymous_user

paver test_system -s lms -t openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess
```