### PR TITLE
Change the hyper link to redirect to course root after signing in

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1488,10 +1488,9 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         if not self.runtime.user_id:
             event_info['failure'] = 'anonymous_user'
             self.track_function_unmask('save_problem_fail', event_info)
-            next_url = urlquote_plus(reverse('jump_to',
+            next_url = urlquote_plus(reverse('about_course',
                                              kwargs={
                                                  'course_id': self.location.course_key,
-                                                 'location': self.location
                                              }))
 
             signin_link = u'{signin_link}?next={next_url}'.format(

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1285,9 +1285,8 @@ class CapaModuleTest(unittest.TestCase):
         they are displayed an error message.
         """
         module = CapaFactory.create(done=False)
-        next_url = urlquote_plus(reverse('jump_to', kwargs={
+        next_url = urlquote_plus(reverse('about_course', kwargs={
             'course_id': module.location.course_key,
-            'location': module.location
         }))
 
         regiteration_link = u'{signin_link}?next={next_url}'.format(


### PR DESCRIPTION
## Story link
https://edlyio.atlassian.net/browse/EDE-426

## Description
In the warning message shown to the user when they try to save the
problem while being anonymous, the hyperlink previously redirected user
back to the problem page after signing in.
This PR changes that and now the user is redirected to course root page
after signing in

![image](https://user-images.githubusercontent.com/42166091/80483035-b851d500-896e-11ea-89e8-27999f058262.png)
