### PR TITLE
update dragndrop link in requirements to install our forked version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -34,7 +34,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1
 -e common/lib/sandbox-packages
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
+git+https://github.com/mitocw/xblock-drag-and-drop-v2@mit-v2.3.0#egg=xblock-drag-and-drop-v2==2.3.0
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e common/lib/xmodule

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -37,7 +37,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1
 -e common/lib/sandbox-packages
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
+git+https://github.com/mitocw/xblock-drag-and-drop-v2@mit-v2.3.0#egg=xblock-drag-and-drop-v2==2.3.0
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e common/lib/xmodule


### PR DESCRIPTION
## Story link:
https://edlyio.atlassian.net/browse/EDE-434

## Description
Update requirements file to point to our forked version of DragnDrop in which public access has been added. (Related PR link: https://github.com/mitocw/xblock-drag-and-drop-v2/pull/1 and https://github.com/mitocw/xblock-drag-and-drop-v2/pull/2)