### PR TITLE
Add public access for content experiment groups

### DIFF
--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -168,6 +168,7 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
         """
         For grading--return just the chosen child.
         """
+        child_descriptor = None
         group_id = self.get_group_id()
         if group_id is None:
             return []
@@ -304,6 +305,12 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
             html = html + rendered_child.content
 
         return html
+
+    def public_view(self, context):
+        """
+        Renders the same content as the student view.
+        """
+        return self.student_view(context)
 
     def student_view(self, context):
         """

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -54,7 +54,10 @@ class RandomUserPartitionScheme(object):
         If the user has not yet been assigned, a group will be randomly chosen for them if assign flag is True.
         """
         partition_key = cls.key_for_partition(user_partition)
-        group_id = course_tag_api.get_course_tag(user, course_key, partition_key)
+
+        group_id = None
+        if user.is_authenticated:
+            group_id = course_tag_api.get_course_tag(user, course_key, partition_key)
 
         group = None
         if group_id is not None:
@@ -80,10 +83,16 @@ class RandomUserPartitionScheme(object):
             # TODO: had a discussion in arch council about making randomization more
             # deterministic (e.g. some hash).  Could do that, but need to be careful not
             # to introduce correlation between users or bias in generation.
-            group = cls.RANDOM.choice(user_partition.groups)
 
-            # persist the value as a course tag
-            course_tag_api.set_course_tag(user, course_key, partition_key, group.id)
+            # For anonymous user, always assign and show the first group to avoid
+            # inconsistency in the content being displayed.
+            if user.is_anonymous:
+                group = user_partition.groups[0]
+            else:
+                group = cls.RANDOM.choice(user_partition.groups)
+
+                # persist the value as a course tag
+                course_tag_api.set_course_tag(user, course_key, partition_key, group.id)
 
             # emit event for analytics
             # FYI - context is always user ID that is logged in, NOT the user id that is


### PR DESCRIPTION
### Story link:
https://edlyio.atlassian.net/browse/EDE-502

### Description:
Allow anonymous users to interact with content in "Content Experiment Groups".

### How to test? 
- Create content experiments in a **public** course
https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/content_experiments/content_experiments_configure.html

- Add components to these groups
- Access the content being an anonymous user and verify that it always shows the first group.
- For authenticated users, a group randomly will be assigned the first time and then that group will be displayed every time while accessing the course content