### PR TITLE
Follow-up customizations requested (mainly in texts)

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1493,20 +1493,22 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
                                                  'course_id': self.location.course_key,
                                              }))
 
-            signin_link = u'{signin_link}?next={next_url}'.format(
-                signin_link=reverse('signin_user'),
+            with_next_url = lambda url: u'{url}?next={next_url}'.format(
+                url=url,
                 next_url=next_url
             )
+            link_start = lambda url: HTML(u'<span><a href="{url}">'.format(url=url))
+            link_end = HTML(u'</a></span>')
+
             error_message = _(
-                u'You need to be {signin_link_start}logged in{signin_link_end} '
-                u'to be able to save your answers.'
+                u'You must be logged in to save your answers. Please {signin_link_start}sign in{signin_link_end}'
+                u' or {register_link_start}register{register_link_end} to use this feature.'
             )
             error_message = Text(error_message).format(
-                signin_link_start=HTML(
-                    '<span><a class="signin-link" href={signin_link}>'.format(
-                        signin_link=signin_link
-                    )),
-                signin_link_end=HTML('</a></span>')
+                signin_link_start=link_start(with_next_url(reverse('signin_user'))),
+                signin_link_end=link_end,
+                register_link_start=link_start(with_next_url(reverse('register_user'))),
+                register_link_end=link_end,
             )
             return {
                 'success': False,

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -781,15 +781,15 @@ class XModuleMixin(XModuleFields, XBlock):
             next_url=next_url
         )
 
-        display_text = _(u'{display_name} is only accessible to enrolled learners.')
-        display_name = self.display_name or u'This content'
+        display_text = _(u'This {display_name} assessment is only available to enrolled learners,')
+        display_name = self.display_name or u'This assessment'
 
         # for anonymous users, show sign-in and register links
         if not self.runtime.user_id:
             display_text += _(
-                u' {sign_in_link_start}Sign in{sign_in_link_end} or '
+                u' please {sign_in_link_start}sign in{sign_in_link_end} or '
                 u'{register_link_start}register{register_link_end}, '
-                u'and enroll in this course to view it.'
+                u'and enroll in this course to view the content.'
             )
             display_text = Text(display_text).format(
                 display_name=display_name,
@@ -801,7 +801,7 @@ class XModuleMixin(XModuleFields, XBlock):
 
         # for logged in users, show "enroll" link only.
         else:
-            display_text += _(u' {enroll_link_start}Enroll{enroll_link_end} in this course to view it.')
+            display_text += _(u' please {enroll_link_start}enroll{enroll_link_end} in this course to view the content.')
             display_text = Text(display_text).format(
                 display_name=display_name,
                 enroll_link_start=link_start(reverse('course_root', kwargs={

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -322,7 +322,8 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
                     enable_unenrolled_access and
                     is_anonymous
                 ):
-                    self.assertContains(response, 'ask questions to the community, and more!')
+                    self.assertContains(response, 'to access all course content, save course progress,'
+                                        ' save responses before submitting, and more!')
                 else:
                     self.assertContains(response, 'You must be enrolled in the course to see course content.')
 

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -121,8 +121,8 @@ def _register_course_home_messages(request, course, user_access, course_start_da
         if COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course.id):
             message_content = ''
             message_title = Text(
-                _('{sign_in_link} or {register_link} to save course progress,'
-                  ' save responses before submitting, ask questions to the community, and more!')
+                _('{sign_in_link} or {register_link} to access all course content,'
+                  ' save course progress, save responses before submitting, and more!')
             ).format(
                 sign_in_link=sign_in_link,
                 register_link=register_link


### PR DESCRIPTION
### Story link:
https://edlyio.atlassian.net/browse/EDE-481

### Related theme PR:
https://github.com/mitocw/openlearninglibrary-theme/pull/65

### Description
Apply the customizations requested in the document (document's link in the ticket).

These changes include:

- Message on course root 
![image](https://user-images.githubusercontent.com/42166091/82438799-0f048780-9ab3-11ea-9537-48e21628f1b1.png)

- Warning message for advanced problems is updated
for anonymous users
![image](https://user-images.githubusercontent.com/42166091/82438848-1f1c6700-9ab3-11ea-854d-4555faaea3df.png)
For authenticated (but not enrolled) users
![image](https://user-images.githubusercontent.com/42166091/82438890-2b082900-9ab3-11ea-9c03-d3943eaee066.png)

- Warning message when a guest user hits the "Save" button on a problem
![image](https://user-images.githubusercontent.com/42166091/82438905-32c7cd80-9ab3-11ea-99d3-7c5465563415.png)

- (in Theme) Add tooltip on course enroll and view course buttons on course about page