### PR TITLE
FIX: the issue in which multiple bookmark buttons were shown for some units

### DIFF
--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -97,8 +97,11 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         }
 
         if view == STUDENT_VIEW:
+            # Do not display "Bookmark" button for children blocks
+            # (e.g. Content Experiment Groups) otherwise multiple
+            # bookmark buttons would be displayed in the same unit/page
             fragment_context.update({
-                'show_bookmark_button': child_context.get('show_bookmark_button', not is_child_of_vertical),
+                'show_bookmark_button': not is_child_of_vertical and child_context.get('show_bookmark_button', True),
                 'bookmarked': child_context['bookmarked'],
                 'bookmark_id': u"{},{}".format(
                     child_context['username'], unicode(self.location)),  # pylint: disable=no-member


### PR DESCRIPTION
### Description
Fixes the bug in which there were multiple bookmark buttons were displayed in the units that have child vertical blocks. (like content experiment groups)

**Before**
![image](https://user-images.githubusercontent.com/42166091/84354494-642b4900-abda-11ea-839a-440db67061c8.png)

**After**
![image](https://user-images.githubusercontent.com/42166091/84354607-9d63b900-abda-11ea-8e84-33a5c1f5d06e.png)
