### PR TITLE
added redirect for hotfix pre-biology towards a course

### DIFF
--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -5,6 +5,8 @@ Course API Views
 import search
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.throttling import UserRateThrottle
 
@@ -16,6 +18,8 @@ from .api import course_detail, list_courses
 from .forms import CourseDetailGetForm, CourseListGetForm
 from .serializers import CourseDetailSerializer, CourseSerializer
 
+# MIT-OLL : course Id for temporary redirection of a course
+BIOLOGY_COURSE_ID = 'course-v1:OCW+Pre-7.01+1T2020'
 
 @view_auth_classes(is_authenticated=False)
 class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
@@ -270,3 +274,7 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             course for course in db_courses
             if unicode(course.id) in search_courses_ids
         ]
+
+
+def redirect_courses(request):
+    return HttpResponseRedirect((reverse('about_course', kwargs={'course_id': BIOLOGY_COURSE_ID})))

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -53,6 +53,9 @@ from student import views as student_views
 from track import views as track_views
 from util import views as util_views
 
+# MIT redirect the url single course hotfix as client asked
+from djangoapps.course_api import views as course_api_view
+
 if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     django_autodiscover()
     admin.site.site_header = _('LMS Administration')
@@ -147,6 +150,9 @@ urlpatterns = [
 
     # robots.txt for mit oll
     url(r'^robots\.txt/$', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
+
+    # redirecting due to high priority hotfix
+    url(r'^pre-biology', course_api_view.redirect_courses, name='redirect_single_course'),
 ]
 
 if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):


### PR DESCRIPTION
As this seems to be not the perfect way to do but as a concern from client-side to fix this on urgent basis this is most appropriate and quick way. 
Redirecting the https://openlearninglibrary.mit.edu/pre-biology -> https://openlearninglibrary.mit.edu/courses/course-v1:OCW+Pre-7.01+1T2020/about 

Ticket link : https://edlyio.atlassian.net/browse/EDE-810