### PR TITLE
add updated tag of django-wiki in requirements

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,7 +8,7 @@
 -e common/lib/capa  # via -r requirements/edx/local.in
 -e git+https://github.com/edx/codejail.git@3.0.1#egg=codejail  # via -r requirements/edx/github.in
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit  # via -r requirements/edx/github.in
--e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/github.in
+-e git+https://github.com/edly-io/django-wiki.git@0.0.27.mit#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
 -e git+https://github.com/mitodl/edx-git-auto-export.git@v0.2#egg=edx-git-auto-export  # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -8,7 +8,7 @@
 -e common/lib/capa  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/codejail.git@3.0.1#egg=codejail  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit  # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/testing.txt
+-e git+https://github.com/edly-io/django-wiki.git@0.0.27.mit#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
 -e git+https://github.com/mitodl/edx-git-auto-export.git@v0.2#egg=edx-git-auto-export  # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -55,7 +55,7 @@
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 
 # Third-party:
--e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki
+-e git+https://github.com/edly-io/django-wiki.git@0.0.27.mit#egg=django-wiki
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -8,7 +8,7 @@
 -e common/lib/capa  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/codejail.git@3.0.1#egg=codejail  # via -r requirements/edx/base.txt
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit  # via -r requirements/edx/base.txt
--e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/base.txt
+-e git+https://github.com/edly-io/django-wiki.git@0.0.27.mit#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
 -e git+https://github.com/mitodl/edx-git-auto-export.git@v0.2#egg=edx-git-auto-export  # via -r requirements/edx/base.txt


### PR DESCRIPTION
This PR includes a fix from https://github.com/edly-io/django-wiki/pull/2