### PR TITLE
Use first and last name fields for user

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -608,6 +608,8 @@ def do_create_account(form, custom_form=None):
     user = User(
         username=proposed_username,
         email=form.cleaned_data["email"],
+        first_name=form.cleaned_data["first_name"],
+        last_name=form.cleaned_data["last_name"],
         is_active=False
     )
     password = normalize_password(form.cleaned_data["password"])
@@ -646,12 +648,13 @@ def do_create_account(form, custom_form=None):
     registration.register(user)
 
     profile_fields = [
-        "name", "level_of_education", "gender", "mailing_address", "city", "country", "goals",
+        "level_of_education", "gender", "mailing_address", "city", "country", "goals",
         "year_of_birth"
     ]
     profile = UserProfile(
         user=user,
-        **{key: form.cleaned_data.get(key) for key in profile_fields}
+        **{key: form.cleaned_data.get(key) for key in profile_fields},
+        name=form.cleaned_data["first_name"] + ' ' + form.cleaned_data["last_name"], 
     )
     extended_profile = form.cleaned_extended_profile
     if extended_profile:

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -212,11 +212,11 @@ class Users(SysadminDashboardView):
         track.views.server_track(request, action, {}, page='user_sysdashboard')
 
         if action == 'download_users':
-            header = [_('username'), _('email'), _('name'), _('country') ]
+            header = [_('username'), _('email'), _('first_name'), _('last_name'), _('country') ]
             data = []
             for u in (User.objects.select_related('profile').iterator()):
                 try:
-                    data.append([u.username, u.email, u.profile.name, u.profile.country])
+                    data.append([u.username, u.email, u.first_name, u.last_name, u.profile.country])
                 except UserProfile.DoesNotExist as err:
                     data.append([u.username, u.email, '', ''])
                     msg = _(u'Cannot find user profile with username {username} - {error}').format(

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3293,7 +3293,8 @@ ACCOUNT_VISIBILITY_CONFIGURATION["bulk_shareable_fields"] = (
 # The list of all fields that can be shared selectively with other users using the 'custom' privacy setting
 ACCOUNT_VISIBILITY_CONFIGURATION["custom_shareable_fields"] = (
     ACCOUNT_VISIBILITY_CONFIGURATION["bulk_shareable_fields"] + [
-        "name",
+        "first_name",
+        "last_name",
     ]
 )
 

--- a/lms/static/js/student_account/models/user_account_model.js
+++ b/lms/static/js/student_account/models/user_account_model.js
@@ -7,7 +7,8 @@
             idAttribute: 'username',
             defaults: {
                 username: '',
-                name: '',
+                first_name: '',
+                last_name: '',
                 email: '',
                 password: '',
                 language: null,

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -36,8 +36,8 @@
                 accountsSectionData, ordersSectionData, accountSettingsView, showAccountSettingsPage,
                 showLoadingError, orderNumber, getUserField, userFields, timeZoneDropdownField, countryDropdownField,
                 emailFieldView, secondaryEmailFieldView, socialFields, accountDeletionFields, platformData,
-                aboutSectionMessageType, aboutSectionMessage, fullnameFieldView, countryFieldView,
-                fullNameFieldData, emailFieldData, secondaryEmailFieldData, countryFieldData, additionalFields,
+                aboutSectionMessageType, aboutSectionMessage, firstNameFieldView, lastNameFieldView, countryFieldView,
+                firstNameFieldData, lastNameFieldData, emailFieldData, secondaryEmailFieldData, countryFieldData, additionalFields,
                 fieldItem, emailFieldViewIndex, focusId,
                 tabIndex = 0;
 
@@ -95,20 +95,37 @@
                 persistChanges: true
             };
 
-            fullNameFieldData = {
+            firstNameFieldData = {
                 model: userAccountModel,
-                title: gettext('Full Name'),
-                valueAttribute: 'name',
-                helpMessage: gettext('The name that is used for ID verification and that appears on your certificates.'),  // eslint-disable-line max-len,
+                title: gettext('First Name'),
+                valueAttribute: 'first_name',
+                helpMessage: gettext('Your first name.'),  // eslint-disable-line max-len,
                 persistChanges: true
             };
-            if (syncLearnerProfileData && enterpriseReadonlyAccountFields.fields.indexOf('name') !== -1) {
-                fullnameFieldView = {
-                    view: new AccountSettingsFieldViews.ReadonlyFieldView(fullNameFieldData)
+            if (syncLearnerProfileData && enterpriseReadonlyAccountFields.fields.indexOf('first_name') !== -1) {
+                firstNameFieldView = {
+                    view: new AccountSettingsFieldViews.ReadonlyFieldView(firstNameFieldData)
                 };
             } else {
-                fullnameFieldView = {
-                    view: new AccountSettingsFieldViews.TextFieldView(fullNameFieldData)
+                firstNameFieldView = {
+                    view: new AccountSettingsFieldViews.TextFieldView(firstNameFieldData)
+                };
+            }
+
+            lastNameFieldData = {
+                model: userAccountModel,
+                title: gettext('Last Name'),
+                valueAttribute: 'last_name',
+                helpMessage: gettext('Your last name.'),  // eslint-disable-line max-len,
+                persistChanges: true
+            }
+            if (syncLearnerProfileData && enterpriseReadonlyAccountFields.fields.indexOf('last_name') !== -1) {
+                lastNameFieldView = {
+                    view: new AccountSettingsFieldViews.ReadonlyFieldView(lastNameFieldData)
+                };
+            } else {
+                lastNameFieldView = {
+                    view: new AccountSettingsFieldViews.TextFieldView(lastNameFieldData)
                 };
             }
 
@@ -154,7 +171,8 @@
                                 )
                             })
                         },
-                        fullnameFieldView,
+                        firstNameFieldView,
+                        lastNameFieldView,
                         emailFieldView,
                         {
                             view: new AccountSettingsFieldViews.PasswordFieldView({

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -141,6 +141,8 @@ class UserReadOnlySerializer(serializers.Serializer):
             "profile_image": None,
             "language_proficiencies": None,
             "name": None,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
             "gender": None,
             "goals": None,
             "year_of_birth": None,
@@ -222,7 +224,7 @@ class AccountUserSerializer(serializers.HyperlinkedModelSerializer, ReadOnlyFiel
     """
     class Meta(object):
         model = User
-        fields = ("username", "email", "date_joined", "is_active")
+        fields = ("username", "first_name", "last_name", "email", "date_joined", "is_active")
         read_only_fields = ("username", "email", "date_joined", "is_active")
         explicit_read_only_fields = ()
 

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -97,7 +97,7 @@ def validate_name(name):
         name (unicode): The name to validate.
     """
     if contains_html(name):
-        raise forms.ValidationError(_('Full Name cannot contain the following characters: < >'))
+        raise forms.ValidationError(_('First/last Name cannot contain the following characters: < >'))
 
 
 class UsernameField(forms.CharField):
@@ -136,7 +136,8 @@ class AccountCreationForm(forms.Form):
     """
 
     _EMAIL_INVALID_MSG = _(u"A properly formatted e-mail is required")
-    _NAME_TOO_SHORT_MSG = _(u"Your legal name must be a minimum of one character long")
+    _FIRST_NAME_TOO_SHORT_MSG = _(u"Your legal first name must be a minimum of one character long")
+    _LAST_NAME_TOO_SHORT_MSG = _(u"Your legal last name must be a minimum of one character long")
 
     # TODO: Resolve repetition
 
@@ -154,11 +155,19 @@ class AccountCreationForm(forms.Form):
 
     password = forms.CharField()
 
-    name = forms.CharField(
+    first_name = forms.CharField(
         min_length=accounts.NAME_MIN_LENGTH,
         error_messages={
-            "required": _NAME_TOO_SHORT_MSG,
-            "min_length": _NAME_TOO_SHORT_MSG,
+            "required": _FIRST_NAME_TOO_SHORT_MSG,
+            "min_length": _FIRST_NAME_TOO_SHORT_MSG,
+        },
+        validators=[validate_name]
+    )
+    last_name = forms.CharField(
+        min_length=accounts.NAME_MIN_LENGTH,
+        error_messages={
+            "required": _LAST_NAME_TOO_SHORT_MSG,
+            "min_length": _LAST_NAME_TOO_SHORT_MSG,
         },
         validators=[validate_name]
     )
@@ -294,12 +303,10 @@ class RegistrationFormFactory(object):
     Construct Registration forms and associated fields.
     """
 
-    DEFAULT_FIELDS = ["email", "name", "username", "password"]
+    DEFAULT_FIELDS = ["email", "first_name", "last_name", "username", "password"]
 
     EXTRA_FIELDS = [
         "confirm_email",
-        "first_name",
-        "last_name",
         "city",
         "state",
         "country",


### PR DESCRIPTION
## Description 

This changes signup form to take first and last name instead of full name. The signup form will look like this:
<img width="548" alt="Screenshot 2023-10-11 at 1 47 01 PM" src="https://github.com/mitocw/edx-platform/assets/106074266/5dee53c6-3608-4e78-aca8-7e16ee922798">

Instead of

<img width="548" alt="Screenshot 2023-10-11 at 1 46 17 PM" src="https://github.com/mitocw/edx-platform/assets/106074266/cec41688-624a-41ed-bb09-3b015f73f470">

And if users want to change their name afterwards accounts settings page will be changed to take first and last name separately as well:

<img width="548" alt="Screenshot 2023-10-11 at 1 53 34 PM" src="https://github.com/mitocw/edx-platform/assets/106074266/66a30811-6144-453e-a2e9-c223c1ed36e7">

Additionally, `sysadmin` report, Download list of all users, will be changed to have first and last name.